### PR TITLE
Convert to Swift 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 `Kronos` adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.0](https://github.com/lyft/Kronos/releases/tag/0.2.0)
+- Added Swift 3 support
+
 ## [0.1.1](https://github.com/lyft/Kronos/releases/tag/0.1.1)
 - Added IPv6 support
 

--- a/Kronos.podspec
+++ b/Kronos.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Kronos'
-  s.version = '0.1.2'
+  s.version = '0.2.0'
   s.license = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
   s.summary = 'Elegant NTP client in Swift'
   s.homepage = 'https://github.com/lyft/Kronos'

--- a/Kronos.xcodeproj/project.pbxproj
+++ b/Kronos.xcodeproj/project.pbxproj
@@ -187,11 +187,11 @@
 				TargetAttributes = {
 					C20174821BD5509D00E4FE18 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0810;
 					};
 					C201748C1BD5509D00E4FE18 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0810;
 					};
 				};
 			};
@@ -356,7 +356,7 @@
 				PRODUCT_NAME = Kronos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
@@ -379,7 +379,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Lyft.Kronos;
 				PRODUCT_NAME = Kronos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
@@ -394,7 +394,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Lyft.KronosTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -407,7 +407,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.Lyft.KronosTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>0.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/Clock.swift
+++ b/Sources/Clock.swift
@@ -19,13 +19,13 @@ public struct Clock {
     private static var stableTime: TimeFreeze?
 
     /// The most accurate timestamp that we have so far (nil if no synchronization was done yet)
-    public static var timestamp: NSTimeInterval? {
+    public static var timestamp: TimeInterval? {
         return self.stableTime?.adjustedTimestamp
     }
 
     /// The most accurate date that we have so far (nil if no synchronization was done yet)
-    public static var now: NSDate? {
-        return self.timestamp.map { NSDate(timeIntervalSince1970: $0) }
+    public static var now: Date? {
+        return self.timestamp.map { Date(timeIntervalSince1970: $0) }
     }
 
     /// Syncs the clock using NTP. Note that the full synchronization could take a few seconds. The given
@@ -39,22 +39,22 @@ public struct Clock {
     /// - parameter completion: A closure that will be called after _all_ the NTP calls are finished.
     /// - parameter first:      A closure that will be called after the first valid date is calculated.
     public static func sync(from pool: String = "time.apple.com", samples: Int = 4,
-                            first: ((date: NSDate, offset: NSTimeInterval) -> Void)? = nil,
-                            completion: ((date: NSDate?, offset: NSTimeInterval?) -> Void)? = nil)
+                            first: ((Date, TimeInterval) -> Void)? = nil,
+                            completion: ((Date?, TimeInterval?) -> Void)? = nil)
     {
         self.reset()
 
-        NTPClient().queryPool(pool, numberOfSamples: samples) { offset, done, total in
+        NTPClient().query(pool: pool, numberOfSamples: samples) { offset, done, total in
             if let offset = offset {
                 self.stableTime = TimeFreeze(offset: offset)
 
                 if done == 1, let now = self.now {
-                    first?(date: now, offset: offset)
+                    first?(now, offset)
                 }
             }
 
             if done == total {
-                completion?(date: self.now, offset: offset)
+                completion?(self.now, offset)
             }
         }
     }

--- a/Sources/NSMutableData+Bytes.swift
+++ b/Sources/NSMutableData+Bytes.swift
@@ -13,7 +13,7 @@ extension NSData {
         let hexArray = Array(hex.characters)
         var bytes: [UInt8] = []
 
-        for index in 0.stride(to: hexArray.count, by: 2) {
+        for index in stride(from: 0, to: hexArray.count, by: 2) {
             guard let byte = UInt8("\(hexArray[index])\(hexArray[index + 1])", radix: 16) else {
                 return nil
             }
@@ -29,7 +29,7 @@ extension NSData {
     /// - parameter index: The index of the byte to be retrieved. Note that this should never be >= length.
     ///
     /// - returns: The byte located at position `index`.
-    func getByte(atIndex index: Int) -> Int8 {
+    func getByte(at index: Int) -> Int8 {
         var data: Int8 = 0
         self.getBytes(&data, range: NSRange(location: index, length: 1))
         return data
@@ -41,7 +41,7 @@ extension NSData {
     ///                    3.
     ///
     /// - returns: The unsigned int located at position `index`.
-    func getUnsignedInteger(atIndex index: Int, bigEndian: Bool = true) -> UInt32 {
+    func getUnsignedInteger(at index: Int, bigEndian: Bool = true) -> UInt32 {
         var data: UInt32 = 0
         self.getBytes(&data, range: NSRange(location: index, length: 4))
         return bigEndian ? data.bigEndian : data.littleEndian
@@ -53,7 +53,7 @@ extension NSData {
     ///                    7.
     ///
     /// - returns: The unsigned long integer located at position `index`.
-    func getUnsignedLong(atIndex index: Int, bigEndian: Bool = true) -> UInt64 {
+    func getUnsignedLong(at index: Int, bigEndian: Bool = true) -> UInt64 {
         var data: UInt64 = 0
         self.getBytes(&data, range: NSRange(location: index, length: 8))
         return bigEndian ? data.bigEndian : data.littleEndian
@@ -67,7 +67,7 @@ extension NSMutableData {
     /// - parameter data: The byte to be appended.
     func append(byte data: Int8) {
         var data = data
-        self.appendBytes(&data, length: 1)
+        self.append(&data, length: 1)
     }
 
     /// Appends the given unsigned integer (32 bits; 4 bytes) into the receiver NSData.
@@ -75,7 +75,7 @@ extension NSMutableData {
     /// - parameter data: The unsigned integer to be appended.
     func append(unsignedInteger data: UInt32, bigEndian: Bool = true) {
         var data = bigEndian ? data.bigEndian : data.littleEndian
-        self.appendBytes(&data, length: 4)
+        self.append(&data, length: 4)
     }
 
     /// Appends the given unsigned long (64 bits; 8 bytes) into the receiver NSData.
@@ -83,6 +83,6 @@ extension NSMutableData {
     /// - parameter data: The unsigned long to be appended.
     func append(unsignedLong data: UInt64, bigEndian: Bool = true) {
         var data = bigEndian ? data.bigEndian : data.littleEndian
-        self.appendBytes(&data, length: 8)
+        self.append(&data, length: 8)
     }
 }

--- a/Sources/NSTimer+ClosureKit.swift
+++ b/Sources/NSTimer+ClosureKit.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-typealias CKTimerHandler = (timer: NSTimer) -> Void
+typealias CKTimerHandler = (Timer) -> Void
 
 /// Simple closure implementation on NSTimer scheduling.
 ///
 /// Example:
 ///
 /// ```swift
-/// BlockTimer.scheduledTimerWithTimeInterval(1.0) { timer in
-///     println("Did something after 1s!")
+/// BlockTimer.scheduledTimer(withTimeInterval: 1.0) { timer in
+///     print("Did something after 1s!")
 /// }
 /// ```
 final class BlockTimer: NSObject {
@@ -21,20 +21,20 @@ final class BlockTimer: NSObject {
     /// - parameter handler:  The closure that the NSTimer fires.
     ///
     /// - returns: A new NSTimer object, configured according to the specified parameters.
-    class func scheduledTimerWithTimeInterval(interval: NSTimeInterval, repeated: Bool = false,
-        handler: CKTimerHandler) -> NSTimer
+    class func scheduledTimer(withTimeInterval interval: TimeInterval, repeated: Bool = false,
+        handler: @escaping CKTimerHandler) -> Timer
     {
-        return NSTimer.scheduledTimerWithTimeInterval(interval, target: self,
-            selector: #selector(BlockTimer.invokeFromTimer(_:)),
+        return Timer.scheduledTimer(timeInterval: interval, target: self,
+            selector: #selector(BlockTimer.invokeFrom(timer:)),
             userInfo: TimerClosureWrapper(handler: handler, repeats: repeated), repeats: repeated)
     }
 
     // MARK: Private methods
 
     @objc
-    class private func invokeFromTimer(timer: NSTimer) {
+    class private func invokeFrom(timer: Timer) {
         if let closureWrapper = timer.userInfo as? TimerClosureWrapper {
-            closureWrapper.handler(timer: timer)
+            closureWrapper.handler(timer)
         }
     }
 }
@@ -42,10 +42,10 @@ final class BlockTimer: NSObject {
 // MARK: - Private classes
 
 private final class TimerClosureWrapper {
-    private var handler: CKTimerHandler
+    fileprivate var handler: CKTimerHandler
     private var repeats: Bool
 
-    init(handler: CKTimerHandler, repeats: Bool) {
+    init(handler: @escaping CKTimerHandler, repeats: Bool) {
         self.handler = handler
         self.repeats = repeats
     }

--- a/Sources/NTPProtocol.swift
+++ b/Sources/NTPProtocol.swift
@@ -1,25 +1,25 @@
 import Foundation
 
 /// Exception raised when the received PDU is invalid.
-enum NTPParsingError: ErrorType {
-    case InvalidNTPPDU(String)
+enum NTPParsingError: Error {
+    case invalidNTPPDU(String)
 }
 
 /// The leap indicator warning of an impending leap second to be inserted or deleted in the last minute of the
 /// current month.
 enum LeapIndicator: Int8 {
-    case NoWarning, SixtyOneSeconds, FiftyNineSeconds, Alarm
+    case noWarning, sixtyOneSeconds, fiftyNineSeconds, alarm
 
     /// Human readable value of the leap warning.
     var description: String {
         switch self {
-            case NoWarning:
+            case .noWarning:
                return "No warning"
-            case SixtyOneSeconds:
+            case .sixtyOneSeconds:
                return "Last minute of the day has 61 seconds"
-            case FiftyNineSeconds:
+            case .fiftyNineSeconds:
                return "Last minute of the day has 59 seconds"
-            case Alarm:
+            case .alarm:
                return "Unknown (clock unsynchronized)"
         }
     }
@@ -27,26 +27,26 @@ enum LeapIndicator: Int8 {
 
 /// The connection mode.
 enum Mode: Int8 {
-    case Reserved, SymmetricActive, SymmetricPassive, Client, Server, Broadcast, ReservedNTP, Unknown
+    case reserved, symmetricActive, symmetricPassive, client, server, broadcast, reservedNTP, unknown
 }
 
 /// Mode representing the statrum level of the clock.
 enum Stratum: Int8 {
-    case Unspecified, Primary, Secondary, Invalid
+    case unspecified, primary, secondary, invalid
 
     init(value: Int8) {
         switch value {
             case 0:
-                self = Unspecified
+                self = .unspecified
 
             case 1:
-                self = Primary
+                self = .primary
 
             case 0 ..< 15:
-                self = Secondary
+                self = .secondary
 
             default:
-                self = Invalid
+                self = .invalid
         }
     }
 }
@@ -57,34 +57,34 @@ enum Stratum: Int8 {
 /// - Debug(id):               Contains the kiss code for debug purposes (stratum 0).
 /// - ReferenceIdentifier(id): The reference identifier of the server (stratum > 1).
 enum ClockSource {
-    case ReferenceClock(id: UInt32, description: String)
-    case Debug(id: UInt32)
-    case ReferenceIdentifier(id: UInt32)
+    case referenceClock(id: UInt32, description: String)
+    case debug(id: UInt32)
+    case referenceIdentifier(id: UInt32)
 
     init(stratum: Stratum, sourceID: UInt32) {
         switch stratum {
-            case .Unspecified:
-                self = Debug(id: sourceID)
+            case .unspecified:
+                self = .debug(id: sourceID)
 
-            case .Primary:
+            case .primary:
                 let (id, description) = ClockSource.description(fromID: sourceID)
-                self = ReferenceClock(id: id, description: description)
+                self = .referenceClock(id: id, description: description)
 
-            case .Secondary, .Invalid:
-                self = ReferenceIdentifier(id: sourceID)
+            case .secondary, .invalid:
+                self = .referenceIdentifier(id: sourceID)
         }
     }
 
     /// The id for the reference clock (IANA, stratum 1), debug (stratum 0) or referenceIdentifier
     var ID: UInt32 {
         switch self {
-            case ReferenceClock(let id, _):
+            case .referenceClock(let id, _):
                 return id
 
-            case Debug(let id):
+            case .debug(let id):
                 return id
 
-            case ReferenceIdentifier(let id):
+            case .referenceIdentifier(let id):
                 return id
         }
     }

--- a/Sources/TimeFreeze.swift
+++ b/Sources/TimeFreeze.swift
@@ -1,22 +1,22 @@
 import Foundation
 
 struct TimeFreeze {
-    private let uptime: NSTimeInterval
-    private let timestamp: NSTimeInterval
-    private let offset: NSTimeInterval
+    private let uptime: TimeInterval
+    private let timestamp: TimeInterval
+    private let offset: TimeInterval
 
     /// The stable timestamp adjusted by the most acurrate offset known so far.
-    var adjustedTimestamp: NSTimeInterval? {
+    var adjustedTimestamp: TimeInterval? {
         return self.offset + self.stableTimestamp
     }
 
     /// The stable timestamp (calculated based on the uptime); note that this doesn't have sub-seconds
     /// precision. See `systemUptime()` for more information.
-    var stableTimestamp: NSTimeInterval {
+    var stableTimestamp: TimeInterval {
         return (TimeFreeze.systemUptime() - self.uptime) + self.timestamp
     }
 
-    init(offset: NSTimeInterval) {
+    init(offset: TimeInterval) {
         self.offset = offset
         self.timestamp = currentTime()
         self.uptime = TimeFreeze.systemUptime()
@@ -30,9 +30,9 @@ struct TimeFreeze {
     /// see: https://github.com/darwin-on-arm/xnu/blob/master/osfmk/kern/clock.c#L522.
     ///
     /// - returns: An Int measurement of system uptime in microseconds.
-    static func systemUptime() -> NSTimeInterval {
+    static func systemUptime() -> TimeInterval {
         var mib = [CTL_KERN, KERN_BOOTTIME]
-        var size = strideof(timeval)
+        var size = MemoryLayout<timeval>.stride
         var bootTime = timeval()
 
         let bootTimeError = sysctl(&mib, u_int(mib.count), &bootTime, &size, nil, 0) != 0

--- a/Tests/Kronos/ClockTests.swift
+++ b/Tests/Kronos/ClockTests.swift
@@ -9,33 +9,34 @@ final class ClockTests: XCTestCase {
     }
 
     func testFirst() {
-        let expectation = self.expectationWithDescription("Clock sync calls first closure")
+        let expectation = self.expectation(description: "Clock sync calls first closure")
         Clock.sync(first: { date, _ in
             XCTAssertNotNil(date)
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(2) { _ in }
+        self.waitForExpectations(timeout: 2) { _ in }
     }
 
     func testLast() {
-        let expectation = self.expectationWithDescription("Clock sync calls last closure")
+        let expectation = self.expectation(description: "Clock sync calls last closure")
         Clock.sync(completion: { date, offset in
             XCTAssertNotNil(date)
             XCTAssertNotNil(offset)
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(10) { _ in }
+        self.waitForExpectations(timeout: 10) { _ in }
     }
 
     func testBoth() {
-        let firstExpectation = self.expectationWithDescription("Clock sync calls first closure")
-        let lastExpectation = self.expectationWithDescription("Clock sync calls last closure")
+        let firstExpectation = self.expectation(description: "Clock sync calls first closure")
+        let lastExpectation = self.expectation(description: "Clock sync calls last closure")
         Clock.sync(
-            completion: { _ in firstExpectation.fulfill() },
-            first: { _ in lastExpectation.fulfill() })
+            first: { _ in lastExpectation.fulfill() },
+            completion: { _ in firstExpectation.fulfill() })
 
-        self.waitForExpectationsWithTimeout(10) { _ in }
+
+        self.waitForExpectations(timeout: 10) { _ in }
     }
 }

--- a/Tests/Kronos/DNSResolverTests.swift
+++ b/Tests/Kronos/DNSResolverTests.swift
@@ -4,42 +4,42 @@ import XCTest
 final class DNSResolverTests: XCTestCase {
 
     func testResolveOneIP() {
-        let expectation = self.expectationWithDescription("Query host's DNS for a single IP")
+        let expectation = self.expectation(description: "Query host's DNS for a single IP")
         DNSResolver.resolve(host: "lyft.com") { addresses in
             XCTAssertEqual(addresses.count, 1)
             expectation.fulfill()
         }
 
-        self.waitForExpectationsWithTimeout(5) { _ in }
+        self.waitForExpectations(timeout: 5) { _ in }
     }
 
     func testResolveMultipleIP() {
-        let expectation = self.expectationWithDescription("Query host's DNS for multiple IPs")
+        let expectation = self.expectation(description: "Query host's DNS for multiple IPs")
         DNSResolver.resolve(host: "pool.ntp.org") { addresses in
             XCTAssertGreaterThan(addresses.count, 1)
             expectation.fulfill()
         }
 
-        self.waitForExpectationsWithTimeout(5) { _ in }
+        self.waitForExpectations(timeout: 5) { _ in }
     }
 
     func testResolveIPv6() {
-        let expectation = self.expectationWithDescription("Query host's DNS that supports IPv6")
+        let expectation = self.expectation(description: "Query host's DNS that supports IPv6")
         DNSResolver.resolve(host: "ipv6friday.org") { addresses in
             XCTAssertGreaterThan(addresses.count, 0)
             expectation.fulfill()
         }
 
-        self.waitForExpectationsWithTimeout(5) { _ in }
+        self.waitForExpectations(timeout: 5) { _ in }
     }
 
     func testInvalidIP() {
-        let expectation = self.expectationWithDescription("Query invalid host's DNS")
+        let expectation = self.expectation(description: "Query invalid host's DNS")
         DNSResolver.resolve(host: "l33t.h4x") { addresses in
             XCTAssertEqual(addresses.count, 0)
             expectation.fulfill()
         }
 
-        self.waitForExpectationsWithTimeout(5) { _ in }
+        self.waitForExpectations(timeout: 5) { _ in }
     }
 }

--- a/Tests/Kronos/NTPClientTests.swift
+++ b/Tests/Kronos/NTPClientTests.swift
@@ -4,12 +4,12 @@ import XCTest
 final class NTPClientTests: XCTestCase {
 
     func testQueryIP() {
-        let expectation = self.expectationWithDescription("NTPClient queries single IPs")
+        let expectation = self.expectation(description: "NTPClient queries single IPs")
 
         DNSResolver.resolve(host: "time.apple.com") { addresses in
             XCTAssertGreaterThan(addresses.count, 0)
 
-            NTPClient().queryIP(addresses.first!, version: 3, numberOfSamples: 1) { PDU in
+            NTPClient().query(ip: addresses.first!, version: 3, numberOfSamples: 1) { PDU in
                 XCTAssertNotNil(PDU)
 
                 XCTAssertGreaterThanOrEqual(PDU!.version, 3)
@@ -19,31 +19,32 @@ final class NTPClientTests: XCTestCase {
             }
         }
 
-        self.waitForExpectationsWithTimeout(10) { _ in }
+        self.waitForExpectations(timeout: 10) { _ in }
     }
 
     func testQueryPool() {
-        let expectation = self.expectationWithDescription("Offset from ref clock to local clock are accurate")
-        NTPClient().queryPool("0.pool.ntp.org", numberOfSamples: 1, maximumServers: 1) { offset, _, _ in
+        let expectation = self.expectation(description: "Offset from ref clock to local clock are accurate")
+        NTPClient().query(pool: "0.pool.ntp.org", numberOfSamples: 1, maximumServers: 1) { offset, _, _ in
             XCTAssertNotNil(offset)
 
-            NTPClient().queryPool("0.pool.ntp.org", numberOfSamples: 1, maximumServers: 1) { offset2, _, _ in
+            NTPClient().query(pool: "0.pool.ntp.org", numberOfSamples: 1, maximumServers: 1)
+            { offset2, _, _ in
                 XCTAssertNotNil(offset2)
                 XCTAssertLessThan(abs(offset! - offset2!), 0.10)
                 expectation.fulfill()
             }
         }
 
-        self.waitForExpectationsWithTimeout(10) { _ in }
+        self.waitForExpectations(timeout: 10) { _ in }
     }
 
     func testQueryPoolWithIPv6() {
-        let expectation = self.expectationWithDescription("NTPClient queries a pool that supports IPv6")
-        NTPClient().queryPool("2.pool.ntp.org", numberOfSamples: 1) { offset, _, _ in
+        let expectation = self.expectation(description: "NTPClient queries a pool that supports IPv6")
+        NTPClient().query(pool: "2.pool.ntp.org", numberOfSamples: 1) { offset, _, _ in
             XCTAssertNotNil(offset)
             expectation.fulfill()
         }
 
-        self.waitForExpectationsWithTimeout(10) { _ in }
+        self.waitForExpectations(timeout: 10) { _ in }
     }
 }

--- a/Tests/Kronos/NTPPacketTests.swift
+++ b/Tests/Kronos/NTPPacketTests.swift
@@ -20,9 +20,9 @@ final class NTPPacketTests: XCTestCase {
                                   "b38bab46dae2d32bb38d9e00")!
         let PDU = try? NTPPacket(data: network, destinationTime: 0)
         XCTAssertEqual(PDU?.version, 3)
-        XCTAssertEqual(PDU?.leap, LeapIndicator.NoWarning)
-        XCTAssertEqual(PDU?.mode, Mode.Server)
-        XCTAssertEqual(PDU?.stratum, Stratum.Secondary)
+        XCTAssertEqual(PDU?.leap, LeapIndicator.noWarning)
+        XCTAssertEqual(PDU?.mode, Mode.server)
+        XCTAssertEqual(PDU?.stratum, Stratum.secondary)
         XCTAssertEqual(PDU?.poll, 3)
         XCTAssertEqual(PDU?.precision, -23)
     }


### PR DESCRIPTION
Update Kronos to work in Swift 3. Includes syntax changes, API changes and renaming according to the Swift 3 API guidelines.