### PR TITLE
Replace NSData with Data

### DIFF
--- a/Kronos.xcodeproj/project.pbxproj
+++ b/Kronos.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		26447D7C1D6E54D400159BEE /* Clock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26447D731D6E54D400159BEE /* Clock.swift */; };
 		26447D7D1D6E54D400159BEE /* DNSResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26447D741D6E54D400159BEE /* DNSResolver.swift */; };
 		26447D7E1D6E54D400159BEE /* InternetAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26447D751D6E54D400159BEE /* InternetAddress.swift */; };
-		26447D7F1D6E54D400159BEE /* NSMutableData+Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26447D761D6E54D400159BEE /* NSMutableData+Bytes.swift */; };
+		26447D7F1D6E54D400159BEE /* Data+Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26447D761D6E54D400159BEE /* Data+Bytes.swift */; };
 		26447D801D6E54D400159BEE /* NSTimer+ClosureKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26447D771D6E54D400159BEE /* NSTimer+ClosureKit.swift */; };
 		26447D811D6E54D400159BEE /* NTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26447D781D6E54D400159BEE /* NTPClient.swift */; };
 		26447D821D6E54D400159BEE /* NTPPacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26447D791D6E54D400159BEE /* NTPPacket.swift */; };
@@ -37,7 +37,7 @@
 		26447D731D6E54D400159BEE /* Clock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Clock.swift; sourceTree = "<group>"; };
 		26447D741D6E54D400159BEE /* DNSResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DNSResolver.swift; sourceTree = "<group>"; };
 		26447D751D6E54D400159BEE /* InternetAddress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternetAddress.swift; sourceTree = "<group>"; };
-		26447D761D6E54D400159BEE /* NSMutableData+Bytes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSMutableData+Bytes.swift"; sourceTree = "<group>"; };
+		26447D761D6E54D400159BEE /* Data+Bytes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Bytes.swift"; sourceTree = "<group>"; };
 		26447D771D6E54D400159BEE /* NSTimer+ClosureKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSTimer+ClosureKit.swift"; sourceTree = "<group>"; };
 		26447D781D6E54D400159BEE /* NTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NTPClient.swift; sourceTree = "<group>"; };
 		26447D791D6E54D400159BEE /* NTPPacket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NTPPacket.swift; sourceTree = "<group>"; };
@@ -111,7 +111,7 @@
 				26447D731D6E54D400159BEE /* Clock.swift */,
 				26447D741D6E54D400159BEE /* DNSResolver.swift */,
 				26447D751D6E54D400159BEE /* InternetAddress.swift */,
-				26447D761D6E54D400159BEE /* NSMutableData+Bytes.swift */,
+				26447D761D6E54D400159BEE /* Data+Bytes.swift */,
 				26447D771D6E54D400159BEE /* NSTimer+ClosureKit.swift */,
 				26447D781D6E54D400159BEE /* NTPClient.swift */,
 				26447D791D6E54D400159BEE /* NTPPacket.swift */,
@@ -223,7 +223,7 @@
 				26447D7D1D6E54D400159BEE /* DNSResolver.swift in Sources */,
 				26447D7E1D6E54D400159BEE /* InternetAddress.swift in Sources */,
 				26447D811D6E54D400159BEE /* NTPClient.swift in Sources */,
-				26447D7F1D6E54D400159BEE /* NSMutableData+Bytes.swift in Sources */,
+				26447D7F1D6E54D400159BEE /* Data+Bytes.swift in Sources */,
 				26447D841D6E54D400159BEE /* TimeFreeze.swift in Sources */,
 				26447D821D6E54D400159BEE /* NTPPacket.swift in Sources */,
 				26447D801D6E54D400159BEE /* NSTimer+ClosureKit.swift in Sources */,

--- a/Sources/DNSResolver.swift
+++ b/Sources/DNSResolver.swift
@@ -36,11 +36,11 @@ final class DNSResolver {
             }
 
             let IPs = (addresses.takeUnretainedValue() as NSArray)
-                .flatMap { $0 as? NSData }
+                .flatMap { $0 as? Data }
                 .flatMap { data -> InternetAddress? in
-                    let socketAddress = data.bytes.bindMemory(to: sockaddr_storage.self,
-                                                              capacity: data.length)
-                    return InternetAddress(storage: socketAddress)
+                    return data.withUnsafeBytes { (pointer: UnsafePointer<sockaddr_storage>) in
+                        return InternetAddress(storage: pointer)
+                    }
                 }
 
             resolver.completion?(IPs)

--- a/Sources/Data+Bytes.swift
+++ b/Sources/Data+Bytes.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-extension NSData {
+extension Data {
 
-    /// Creates an NSData instace based on a hex string (example: "ffff" would be <FF FF>).
+    /// Creates an Data instace based on a hex string (example: "ffff" would be <FF FF>).
     ///
     /// - parameter hex: The hex string without any spaces; should only have [0-9A-Fa-f].
-    convenience init?(hex: String) {
+    init?(hex: String) {
         if hex.characters.count % 2 != 0 {
             return nil
         }
@@ -21,7 +21,7 @@ extension NSData {
             bytes.append(byte)
         }
 
-        self.init(bytes: bytes, length: bytes.count)
+        self.init(bytes: bytes, count: bytes.count)
     }
 
     /// Gets one byte from the given index.
@@ -30,8 +30,7 @@ extension NSData {
     ///
     /// - returns: The byte located at position `index`.
     func getByte(at index: Int) -> Int8 {
-        var data: Int8 = 0
-        self.getBytes(&data, range: NSRange(location: index, length: 1))
+        let data: Int8 = self.subdata(in: index ..< (index + 1)).withUnsafeBytes { $0.pointee }
         return data
     }
 
@@ -42,8 +41,7 @@ extension NSData {
     ///
     /// - returns: The unsigned int located at position `index`.
     func getUnsignedInteger(at index: Int, bigEndian: Bool = true) -> UInt32 {
-        var data: UInt32 = 0
-        self.getBytes(&data, range: NSRange(location: index, length: 4))
+        let data: UInt32 =  self.subdata(in: index ..< (index + 4)).withUnsafeBytes { $0.pointee }
         return bigEndian ? data.bigEndian : data.littleEndian
     }
 
@@ -54,35 +52,32 @@ extension NSData {
     ///
     /// - returns: The unsigned long integer located at position `index`.
     func getUnsignedLong(at index: Int, bigEndian: Bool = true) -> UInt64 {
-        var data: UInt64 = 0
-        self.getBytes(&data, range: NSRange(location: index, length: 8))
+        let data: UInt64 = self.subdata(in: index ..< (index + 8)).withUnsafeBytes { $0.pointee }
         return bigEndian ? data.bigEndian : data.littleEndian
     }
-}
 
-extension NSMutableData {
 
-    /// Appends the given byte (8 bits) into the receiver NSData.
+    /// Appends the given byte (8 bits) into the receiver Data.
     ///
     /// - parameter data: The byte to be appended.
-    func append(byte data: Int8) {
+    mutating func append(byte data: Int8) {
         var data = data
-        self.append(&data, length: 1)
+        self.append(UnsafeBufferPointer(start: &data, count: 1))
     }
 
-    /// Appends the given unsigned integer (32 bits; 4 bytes) into the receiver NSData.
+    /// Appends the given unsigned integer (32 bits; 4 bytes) into the receiver Data.
     ///
     /// - parameter data: The unsigned integer to be appended.
-    func append(unsignedInteger data: UInt32, bigEndian: Bool = true) {
+    mutating func append(unsignedInteger data: UInt32, bigEndian: Bool = true) {
         var data = bigEndian ? data.bigEndian : data.littleEndian
-        self.append(&data, length: 4)
+        self.append(UnsafeBufferPointer(start: &data, count: 1))
     }
 
-    /// Appends the given unsigned long (64 bits; 8 bytes) into the receiver NSData.
+    /// Appends the given unsigned long (64 bits; 8 bytes) into the receiver Data.
     ///
     /// - parameter data: The unsigned long to be appended.
-    func append(unsignedLong data: UInt64, bigEndian: Bool = true) {
+    mutating func append(unsignedLong data: UInt64, bigEndian: Bool = true) {
         var data = bigEndian ? data.bigEndian : data.littleEndian
-        self.append(&data, length: 8)
+        self.append(UnsafeBufferPointer(start: &data, count: 1))
     }
 }

--- a/Sources/InternetAddress.swift
+++ b/Sources/InternetAddress.swift
@@ -64,11 +64,11 @@ enum InternetAddress: Hashable {
         switch self {
             case .ipv6(var address):
                 address.sin6_port = in_port_t(port).bigEndian
-                return NSData(bytes: &address, length: MemoryLayout<sockaddr_in6>.size) as CFData
+                return Data(bytes: &address, count: MemoryLayout<sockaddr_in6>.size) as CFData
 
             case .ipv4(var address):
                 address.sin_port = in_port_t(port).bigEndian
-                return NSData(bytes: &address, length: MemoryLayout<sockaddr_in>.size) as CFData
+                return Data(bytes: &address, count: MemoryLayout<sockaddr_in>.size) as CFData
         }
     }
 }

--- a/Sources/NTPClient.swift
+++ b/Sources/NTPClient.swift
@@ -5,7 +5,7 @@ private let kDefaultSamples = 4
 private let kMaximumNTPServers = 5
 private let kMaximumResultDispersion = 10.0
 
-private typealias ObjCCompletionType = @convention(block) (NSData?, TimeInterval) -> Void
+private typealias ObjCCompletionType = @convention(block) (Data?, TimeInterval) -> Void
 
 /// Exception raised while sending / receiving NTP packets.
 enum NTPNetworkError: Error {
@@ -148,11 +148,8 @@ final class NTPClient {
         let callback: CFSocketCallBack = { socket, callbackType, address, data, info in
             if callbackType == .writeCallBack {
                 var packet = NTPPacket()
-                let PDU = packet.prepareToSend()
-                let data = CFDataCreate(kCFAllocatorDefault,
-                                        PDU.bytes.bindMemory(to: UInt8.self, capacity: PDU.length),
-                                        PDU.length)
-                CFSocketSendData(socket, nil, data, kDefaultTimeout)
+                let PDU = packet.prepareToSend() as CFData
+                CFSocketSendData(socket, nil, PDU, kDefaultTimeout)
                 return
             }
 
@@ -166,7 +163,7 @@ final class NTPClient {
             let retainedClosure = Unmanaged<AnyObject>.fromOpaque(info)
             let completion = unsafeBitCast(retainedClosure.takeUnretainedValue(), to: ObjCCompletionType.self)
 
-            let data = unsafeBitCast(data, to: CFData.self) as NSData?
+            let data = unsafeBitCast(data, to: CFData.self) as Data?
             completion(data, destinationTime)
             retainedClosure.release()
         }

--- a/Sources/NTPPacket.swift
+++ b/Sources/NTPPacket.swift
@@ -95,9 +95,9 @@ struct NTPPacket {
     /// - parameter data:            The PDU received from the NTP call.
     /// - parameter destinationTime: The time where the package arrived (client time) in EPOCH format.
     /// - throws:                    NTPParsingError in case of an invalid response.
-    init(data: NSData, destinationTime: TimeInterval) throws {
-        if data.length < 48 {
-            throw NTPParsingError.invalidNTPPDU("Invalid PDU length: \(data.length)")
+    init(data: Data, destinationTime: TimeInterval) throws {
+        if data.count < 48 {
+            throw NTPParsingError.invalidNTPPDU("Invalid PDU length: \(data.count)")
         }
 
         self.leap = LeapIndicator(rawValue: (data.getByte(at: 0) >> 6) & 0b11) ?? .noWarning
@@ -119,8 +119,8 @@ struct NTPPacket {
     /// Convert this NTPPacket to a buffer that can be sent over a socket.
     ///
     /// - returns: A bytes buffer representing this packet.
-    mutating func prepareToSend(transmitTime: TimeInterval? = nil) -> NSData {
-        let data = NSMutableData()
+    mutating func prepareToSend(transmitTime: TimeInterval? = nil) -> Data {
+        var data = Data()
         data.append(byte: self.leap.rawValue << 6 | self.version << 3 | self.mode.rawValue)
         data.append(byte: self.stratum.rawValue)
         data.append(byte: self.poll)
@@ -134,7 +134,7 @@ struct NTPPacket {
 
         self.transmitTime = transmitTime ?? currentTime()
         data.append(unsignedLong: self.dateToNTPFormat(self.transmitTime))
-        return data as NSData
+        return data
     }
 
     /// Checks properties to make sure that the received PDU is a valid response that we can use.

--- a/Tests/Kronos/NTPPacketTests.swift
+++ b/Tests/Kronos/NTPPacketTests.swift
@@ -5,19 +5,19 @@ final class NTPPacketTests: XCTestCase {
     func testToData() {
         var packet = NTPPacket()
         let data = packet.prepareToSend(transmitTime: 1463303662.776552)
-        XCTAssertEqual(data, NSData(hex: "1b0004fa0001000000010000000000000000000000000000" +
-                                         "00000000000000000000000000000000dae2bc6ec6cc1c00")!)
+        XCTAssertEqual(data, Data(hex: "1b0004fa0001000000010000000000000000000000000000" +
+                                       "00000000000000000000000000000000dae2bc6ec6cc1c00")!)
     }
 
     func testParseInvalidData() {
-        let network = NSData(hex: "0badface")!
+        let network = Data(hex: "0badface")!
         let PDU = try? NTPPacket(data: network, destinationTime: 0)
         XCTAssertNil(PDU)
     }
 
     func testParseData() {
-        let network = NSData(hex: "1c0203e90000065700000a68ada2c09cdae2d084a5a76d5fdae2d3354a529000dae2d32b" +
-                                  "b38bab46dae2d32bb38d9e00")!
+        let network = Data(hex: "1c0203e90000065700000a68ada2c09cdae2d084a5a76d5fdae2d3354a529000dae2d32b" +
+                                "b38bab46dae2d32bb38d9e00")!
         let PDU = try? NTPPacket(data: network, destinationTime: 0)
         XCTAssertEqual(PDU?.version, 3)
         XCTAssertEqual(PDU?.leap, LeapIndicator.noWarning)
@@ -28,8 +28,8 @@ final class NTPPacketTests: XCTestCase {
     }
 
     func testParseTimeData() {
-        let network = NSData(hex: "1c0203e90000065700000a68ada2c09cdae2d084a5a76d5fdae2d3354a529000dae2d32b" +
-                                  "b38bab46dae2d32bb38d9e00")!
+        let network = Data(hex: "1c0203e90000065700000a68ada2c09cdae2d084a5a76d5fdae2d3354a529000dae2d32b" +
+                                "b38bab46dae2d32bb38d9e00")!
         let PDU = try? NTPPacket(data: network, destinationTime: 0)
         XCTAssertEqual(PDU?.rootDelay, 0.0247650146484375)
         XCTAssertEqual(PDU?.rootDispersion, 0.0406494140625)


### PR DESCRIPTION
During conversion to Swift 3, we kept `NSData` because its API for dealing
with bytes has a huge diff to `Data`. Now we fix it by fully replacing `NSData`
and following the API changes.