### PR TITLE
adjust TimeFreeze on reboot rather than dropping it

### DIFF
--- a/Sources/TimeFreeze.swift
+++ b/Sources/TimeFreeze.swift
@@ -26,7 +26,7 @@ struct TimeFreeze {
         self.uptime = TimeFreeze.systemUptime()
     }
 
-    init?(from dictionary: [String: TimeInterval], dropOnReboot: Bool = true) {
+    init?(from dictionary: [String: TimeInterval]) {
         guard let uptime = dictionary[kUptimeKey], let timestamp = dictionary[kTimestampKey],
             let offset = dictionary[kOffsetKey] else
         {
@@ -37,14 +37,12 @@ struct TimeFreeze {
         let currentTimestamp = currentTime()
         let currentBoot = currentUptime - currentTimestamp
         let previousBoot = uptime - timestamp
-        if rint(currentBoot) - rint(previousBoot) == 0 {
-            self.uptime = uptime
-            self.timestamp = timestamp
-        } else if !dropOnReboot {
+        if rint(currentBoot) - rint(previousBoot) != 0 {
             self.uptime = currentUptime
             self.timestamp = currentTimestamp
         } else {
-            return nil
+            self.uptime = uptime
+            self.timestamp = timestamp
         }
         self.offset = offset
     }

--- a/Sources/TimeFreeze.swift
+++ b/Sources/TimeFreeze.swift
@@ -26,21 +26,26 @@ struct TimeFreeze {
         self.uptime = TimeFreeze.systemUptime()
     }
 
-    init?(from dictionary: [String: TimeInterval]) {
+    init?(from dictionary: [String: TimeInterval], dropOnReboot: Bool = true) {
         guard let uptime = dictionary[kUptimeKey], let timestamp = dictionary[kTimestampKey],
             let offset = dictionary[kOffsetKey] else
         {
             return nil
         }
 
-        let currentBoot = TimeFreeze.systemUptime() - currentTime()
+        let currentUptime = TimeFreeze.systemUptime()
+        let currentTimestamp = currentTime()
+        let currentBoot = currentUptime - currentTimestamp
         let previousBoot = uptime - timestamp
-        if rint(currentBoot) - rint(previousBoot) != 0 {
+        if rint(currentBoot) - rint(previousBoot) == 0 {
+            self.uptime = uptime
+            self.timestamp = timestamp
+        } else if !dropOnReboot {
+            self.uptime = currentUptime
+            self.timestamp = currentTimestamp
+        } else {
             return nil
         }
-
-        self.uptime = uptime
-        self.timestamp = timestamp
         self.offset = offset
     }
 


### PR DESCRIPTION
Good can be better then None. We'd rather have the
best guess at the correct time rather than no time at all, so rather
than dropping a persisted TimeFreeze on reboot, assume the current device
time is consistent with the previous device time.