### PR TITLE
Add CocoaPods tvOS Support

### DIFF
--- a/Kronos.podspec
+++ b/Kronos.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
+  s.tvos.deployment_target = '9.0'
 
   s.source_files = 'Sources/*.swift'
 end


### PR DESCRIPTION
Kronos doesn't currently build for tvOS (via CocoaPods). Support is simple enough, though!