### PR TITLE
make loadFromDefaults public

### DIFF
--- a/Sources/Clock.swift
+++ b/Sources/Clock.swift
@@ -72,7 +72,7 @@ public struct Clock {
         self.stableTime = nil
     }
 
-    private static func loadFromDefaults() {
+    public static func loadFromDefaults() {
         guard let previousStableTime = self.storage.stableTime else {
             self.stableTime = nil
             return


### PR DESCRIPTION
use case scenario: a sandboxed process needs to load from the saved sync
of another non-sandboxed process without attempting to connect to NTP servers.

this sandboxed procs scenarios happens with NetworkingExtension.