### PR TITLE
Expose current NTP time along with associated analytical metadata

### DIFF
--- a/Sources/Clock.swift
+++ b/Sources/Clock.swift
@@ -1,7 +1,14 @@
 import Foundation
 
 /// Struct that has time + related metadata
-public typealias FullTime = (Date, TimeInterval)
+public typealias AnnotatedTime = (
+
+    /// Time that is being annotated
+    date: Date,
+
+    /// Amount of time that has passed since the last NTP sync; in other words, the NTP response age.
+    timeSinceLastNtpSync: TimeInterval
+)
 
 /// High level implementation for clock synchronization using NTP. All returned dates use the most accurate
 /// synchronization and it's not affected by clock changes. The NTP synchronization implementation has sub-
@@ -35,11 +42,17 @@ public struct Clock {
 
     /// The most accurate date that we have so far (nil if no synchronization was done yet)
     public static var now: Date? {
-        return self.fullNow?.0
+        return self.annotatedlNow?.0
     }
 
-    public static var fullNow: FullTime? {
-        return self.stableTime?.fullTime
+    /// Same as `now` except with analytic metadata about the time
+    public static var annotatedlNow: AnnotatedTime? {
+        guard let stableTime = self.stableTime else {
+            return nil
+        }
+
+        return AnnotatedTime(date: Date(timeIntervalSince1970: stableTime.adjustedTimestamp),
+                             timeSinceLastNtpSync: stableTime.timeSinceLastNtpSync)
     }
 
     /// Syncs the clock using NTP. Note that the full synchronization could take a few seconds. The given

--- a/Sources/Clock.swift
+++ b/Sources/Clock.swift
@@ -1,16 +1,7 @@
 import Foundation
 
 /// Struct that has time + related metadata
-public struct FullTime {
-    /// The most accurate timetstamp that we have so far
-    let date: Date
-
-    /// Amount of time that has passed since the last NTP sync; in other words, the NTP response age.
-    /// If the NTP response is one deserialized from disk, and we notice the phone has been rebooted since
-    /// serialization time, we can't know how old the response is, since we use the time-since-boot to measure
-    /// duration. Thus, in this case, this value will be nil.
-    let timeSinceLastNtpSync: TimeInterval?
-}
+public typealias FullTime = (Date, TimeInterval)
 
 /// High level implementation for clock synchronization using NTP. All returned dates use the most accurate
 /// synchronization and it's not affected by clock changes. The NTP synchronization implementation has sub-
@@ -44,7 +35,7 @@ public struct Clock {
 
     /// The most accurate date that we have so far (nil if no synchronization was done yet)
     public static var now: Date? {
-        return self.fullNow?.date
+        return self.fullNow?.0
     }
 
     public static var fullNow: FullTime? {

--- a/Sources/Clock.swift
+++ b/Sources/Clock.swift
@@ -42,7 +42,7 @@ public struct Clock {
 
     /// The most accurate date that we have so far (nil if no synchronization was done yet)
     public static var now: Date? {
-        return self.annotatedlNow?.0
+        return self.annotatedlNow?.data
     }
 
     /// Same as `now` except with analytic metadata about the time

--- a/Sources/Clock.swift
+++ b/Sources/Clock.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+/// Struct that has time + related metadata
+public struct FullTime {
+    /// The most accurate timetstamp that we have so far
+    let date: Date
+
+    /// Amount of time that has passed since the last NTP sync; in other words, the NTP response age.
+    /// If the NTP response is one deserialized from disk, and we notice the phone has been rebooted since
+    /// serialization time, we can't know how old the response is, since we use the time-since-boot to measure
+    /// duration. Thus, in this case, this value will be nil.
+    let timeSinceLastNtpSync: TimeInterval?
+}
+
 /// High level implementation for clock synchronization using NTP. All returned dates use the most accurate
 /// synchronization and it's not affected by clock changes. The NTP synchronization implementation has sub-
 /// second accuracy but given that Darwin doesn't support microseconds on bootTime, dates don't have sub-
@@ -32,7 +44,11 @@ public struct Clock {
 
     /// The most accurate date that we have so far (nil if no synchronization was done yet)
     public static var now: Date? {
-        return self.timestamp.map { Date(timeIntervalSince1970: $0) }
+        return self.fullNow?.date
+    }
+
+    public static var fullNow: FullTime? {
+        return self.stableTime?.fullTime
     }
 
     /// Syncs the clock using NTP. Note that the full synchronization could take a few seconds. The given

--- a/Sources/Clock.swift
+++ b/Sources/Clock.swift
@@ -42,7 +42,7 @@ public struct Clock {
 
     /// The most accurate date that we have so far (nil if no synchronization was done yet)
     public static var now: Date? {
-        return self.annotatedlNow?.data
+        return self.annotatedlNow?.date
     }
 
     /// Same as `now` except with analytic metadata about the time

--- a/Sources/NTPClient.swift
+++ b/Sources/NTPClient.swift
@@ -91,13 +91,14 @@ final class NTPClient {
 
             timer?.invalidate()
             guard
-                let data = data, let PDU = try? NTPPacket(data: data, destinationTime: destinationTime) else
+                let data = data, let PDU = try? NTPPacket(data: data, destinationTime: destinationTime),
+                PDU.isValidResponse() else
             {
                 completion(nil)
                 return
             }
 
-            completion(PDU.isValidResponse() ? PDU : nil)
+            completion(PDU)
         }
 
         let callback = unsafeBitCast(bridgeCallback, to: AnyObject.self)

--- a/Sources/TimeFreeze.swift
+++ b/Sources/TimeFreeze.swift
@@ -20,12 +20,9 @@ struct TimeFreeze {
         return (TimeFreeze.systemUptime() - self.uptime) + self.timestamp
     }
 
-    /// Returns the time plus analytical metadata about the time.
-    ///
-    /// See explanation of fields in the comment for the FullTime struct fore more info.
-    var fullTime: FullTime? {
-        return FullTime(date: Date(timeIntervalSince1970: adjustedTimestamp),
-                        timeSinceLastNtpSync: TimeFreeze.systemUptime() - uptime)
+    /// Time interval between now and the time the NTP response represented by this TimeFreeze was received.
+    var timeSinceLastNtpSync: TimeInterval {
+        return TimeFreeze.systemUptime() - uptime
     }
 
     init(offset: TimeInterval) {

--- a/Sources/TimeFreeze.swift
+++ b/Sources/TimeFreeze.swift
@@ -20,6 +20,14 @@ struct TimeFreeze {
         return (TimeFreeze.systemUptime() - self.uptime) + self.timestamp
     }
 
+    /// Returns the time plus analytical metadata about the time.
+    ///
+    /// See explanation of fields in the comment for the FullTime struct fore more info.
+    var fullTime: FullTime? {
+        return FullTime(date: Date(timeIntervalSince1970: adjustedTimestamp),
+                        timeSinceLastNtpSync: TimeFreeze.systemUptime() - uptime)
+    }
+
     init(offset: TimeInterval) {
         self.offset = offset
         self.timestamp = currentTime()

--- a/Tests/KronosTests/NTPClientTests.swift
+++ b/Tests/KronosTests/NTPClientTests.swift
@@ -23,8 +23,7 @@ final class NTPClientTests: XCTestCase {
     }
 
     func testQueryPool() {
-        var expectation: XCTestExpectation? =
-            self.expectation(description: "Offset from ref clock to local clock are accurate")
+        let expectation = self.expectation(description: "Offset from ref clock to local clock are accurate")
         NTPClient().query(pool: "0.pool.ntp.org", numberOfSamples: 1, maximumServers: 1) { offset, _, _ in
             XCTAssertNotNil(offset)
 
@@ -32,8 +31,7 @@ final class NTPClientTests: XCTestCase {
             { offset2, _, _ in
                 XCTAssertNotNil(offset2)
                 XCTAssertLessThan(abs(offset! - offset2!), 0.10)
-                expectation?.fulfill()
-                expectation = nil
+                expectation.fulfill()
             }
         }
 
@@ -41,12 +39,10 @@ final class NTPClientTests: XCTestCase {
     }
 
     func testQueryPoolWithIPv6() {
-        var expectation: XCTestExpectation? =
-            self.expectation(description: "NTPClient queries a pool that supports IPv6")
-        NTPClient().query(pool: "2.pool.ntp.org", numberOfSamples: 1) { offset, _, _ in
+        let expectation = self.expectation(description: "NTPClient queries a pool that supports IPv6")
+        NTPClient().query(pool: "2.pool.ntp.org", numberOfSamples: 1, maximumServers: 1) { offset, _, _ in
             XCTAssertNotNil(offset)
-            expectation?.fulfill()
-            expectation = nil
+            expectation.fulfill()
         }
 
         self.waitForExpectations(timeout: 10)

--- a/Tests/KronosTests/NTPClientTests.swift
+++ b/Tests/KronosTests/NTPClientTests.swift
@@ -23,7 +23,8 @@ final class NTPClientTests: XCTestCase {
     }
 
     func testQueryPool() {
-        let expectation = self.expectation(description: "Offset from ref clock to local clock are accurate")
+        var expectation: XCTestExpectation? =
+            self.expectation(description: "Offset from ref clock to local clock are accurate")
         NTPClient().query(pool: "0.pool.ntp.org", numberOfSamples: 1, maximumServers: 1) { offset, _, _ in
             XCTAssertNotNil(offset)
 
@@ -31,7 +32,8 @@ final class NTPClientTests: XCTestCase {
             { offset2, _, _ in
                 XCTAssertNotNil(offset2)
                 XCTAssertLessThan(abs(offset! - offset2!), 0.10)
-                expectation.fulfill()
+                expectation?.fulfill()
+                expectation = nil
             }
         }
 
@@ -39,10 +41,12 @@ final class NTPClientTests: XCTestCase {
     }
 
     func testQueryPoolWithIPv6() {
-        let expectation = self.expectation(description: "NTPClient queries a pool that supports IPv6")
+        var expectation: XCTestExpectation? =
+            self.expectation(description: "NTPClient queries a pool that supports IPv6")
         NTPClient().query(pool: "2.pool.ntp.org", numberOfSamples: 1) { offset, _, _ in
             XCTAssertNotNil(offset)
-            expectation.fulfill()
+            expectation?.fulfill()
+            expectation = nil
         }
 
         self.waitForExpectations(timeout: 10)


### PR DESCRIPTION
Time since last NTP sync can be a good indicator of the "fresh"-ness of a vended NTP time.

Does not replace existing APIs; callers can continue to get the timestamp as a `TimeInterval` directly rather than a struct that wraps it.