### PR TITLE
Don't restore from storage after reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 `Kronos` adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.0.1](https://github.com/lyft/Kronos/releases/tag/3.0.1)
+- Don't restore timestamps from the cache after a reboot
+
 ## [3.0.0](https://github.com/lyft/Kronos/releases/tag/3.0.0)
 - Update for Swift 4.2
 

--- a/Sources/TimeFreeze.swift
+++ b/Sources/TimeFreeze.swift
@@ -38,12 +38,11 @@ struct TimeFreeze {
         let currentBoot = currentUptime - currentTimestamp
         let previousBoot = uptime - timestamp
         if rint(currentBoot) - rint(previousBoot) != 0 {
-            self.uptime = currentUptime
-            self.timestamp = currentTimestamp
-        } else {
-            self.uptime = uptime
-            self.timestamp = timestamp
+            return nil
         }
+
+        self.uptime = uptime
+        self.timestamp = timestamp
         self.offset = offset
     }
 

--- a/Sources/TimeFreeze.swift
+++ b/Sources/TimeFreeze.swift
@@ -10,7 +10,7 @@ struct TimeFreeze {
     private let offset: TimeInterval
 
     /// The stable timestamp adjusted by the most acurrate offset known so far.
-    var adjustedTimestamp: TimeInterval? {
+    var adjustedTimestamp: TimeInterval {
         return self.offset + self.stableTimestamp
     }
 

--- a/Tests/KronosTests/TimeStorageTests.swift
+++ b/Tests/KronosTests/TimeStorageTests.swift
@@ -26,8 +26,20 @@ class TimeStorageTests: XCTestCase {
         var storage = TimeStorage(storagePolicy: .standard)
         let sampleFreeze = TimeFreeze(offset: 5000.32423)
         storage.stableTime = sampleFreeze
+
         let fromDefaults = storage.stableTime
         XCTAssertNotNil(fromDefaults)
         XCTAssertEqual(sampleFreeze.toDictionary(), fromDefaults!.toDictionary())
+    }
+
+    func testRetrievingTimeFreezeAfterReboot() {
+        let sampleFreeze = TimeFreeze(offset: 5000.32423)
+        var storedData = sampleFreeze.toDictionary()
+        storedData["Uptime"] = storedData["Uptime"]! + 10
+
+        let beforeRebootFreeze = TimeFreeze(from: sampleFreeze.toDictionary())
+        let afterRebootFreeze = TimeFreeze(from: storedData)
+        XCTAssertNil(afterRebootFreeze)
+        XCTAssertNotNil(beforeRebootFreeze)
     }
 }


### PR DESCRIPTION
If the device clock changes after reboot before Kronos is updated, the "trusted" time will be wrong since we'll apply the offset to the wrong ground time. This breaks the "trusted" guarantee.