### PR TITLE
Don't bind sockaddr into sockaddr_storage unsafely

### DIFF
--- a/Example/main.swift
+++ b/Example/main.swift
@@ -40,7 +40,7 @@ final class ASCIIClock {
         refresh()
 
         // Handle window resizing
-        let handleWinch: @convention(c) Int32 -> Void = { signal in
+        let handleWinch: @convention(c) Int32 -> Void = { _ in
             endwin()
             refresh()
             clear()

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ install-tvOS:
 	true
 
 install-lint:
-	brew remove swiftlint --force || true
-	brew install --force-bottle https://raw.githubusercontent.com/Homebrew/homebrew-core/a97c85994a3f714355a20511b4df3a546ae809cf/Formula/swiftlint.rb
+	brew install swiftlint || true
 
 # Run Tasks
 

--- a/Sources/DNSResolver.swift
+++ b/Sources/DNSResolver.swift
@@ -36,13 +36,8 @@ final class DNSResolver {
             }
 
             let IPs = (addresses.takeUnretainedValue() as NSArray)
-                .compactMap { $0 as? Data }
-                .compactMap { data -> InternetAddress? in
-                    return data.withUnsafeBytes { rawPointer in
-                        let pointer = rawPointer.bindMemory(to: sockaddr_storage.self).baseAddress
-                        return InternetAddress(storage: pointer!)
-                    }
-                }
+                .compactMap { $0 as? NSData }
+                .compactMap(InternetAddress.init)
 
             resolver.completion?(IPs)
             retainedSelf.release()

--- a/Sources/DNSResolver.swift
+++ b/Sources/DNSResolver.swift
@@ -19,7 +19,7 @@ final class DNSResolver {
     static func resolve(host: String, timeout: TimeInterval = kDefaultTimeout,
                         completion: @escaping ([InternetAddress]) -> Void)
     {
-        let callback: CFHostClientCallBack = { host, hostinfo, error, info in
+        let callback: CFHostClientCallBack = { host, _, _, info in
             guard let info = info else {
                 return
             }

--- a/Sources/NTPClient.swift
+++ b/Sources/NTPClient.swift
@@ -149,7 +149,7 @@ final class NTPClient {
     {
         signal(SIGPIPE, SIG_IGN)
 
-        let callback: CFSocketCallBack = { socket, callbackType, address, data, info in
+        let callback: CFSocketCallBack = { socket, callbackType, _, data, info in
             if callbackType == .writeCallBack {
                 var packet = NTPPacket()
                 let PDU = packet.prepareToSend() as CFData

--- a/Tests/KronosTests/DNSResolverTests.swift
+++ b/Tests/KronosTests/DNSResolverTests.swift
@@ -5,7 +5,7 @@ final class DNSResolverTests: XCTestCase {
 
     func testResolveOneIP() {
         let expectation = self.expectation(description: "Query host's DNS for a single IP")
-        DNSResolver.resolve(host: "lyft.com") { addresses in
+        DNSResolver.resolve(host: "test.com") { addresses in
             XCTAssertEqual(addresses.count, 1)
             expectation.fulfill()
         }


### PR DESCRIPTION
By binding sockaddr into a sockaddr_storage we are actually assigning random memory bytes into the sockaddr_storage structre since sockaddr_t is actually smaller than sockaddr_storage.