### PR TITLE
Fix a number of typos in source code documentation

### DIFF
--- a/Sources/Data+Bytes.swift
+++ b/Sources/Data+Bytes.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension Data {
 
-    /// Creates an Data instace based on a hex string (example: "ffff" would be <FF FF>).
+    /// Creates an Data instance based on a hex string (example: "ffff" would be <FF FF>).
     ///
     /// - parameter hex: The hex string without any spaces; should only have [0-9A-Fa-f].
     init?(hex: String) {

--- a/Sources/InternetAddress.swift
+++ b/Sources/InternetAddress.swift
@@ -78,7 +78,7 @@ func == (lhs: InternetAddress, rhs: InternetAddress) -> Bool {
 // MARK: - sockaddr_storage helpers
 
 extension sockaddr_storage {
-    /// Creates a new storage value from a data type that cointains the memory layout of a sockaddr_t. This
+    /// Creates a new storage value from a data type that contains the memory layout of a sockaddr_t. This
     /// is used to create sockaddr_storage(s) from some of the CF C functions such as `CFHostGetAddressing`.
     ///
     /// !!! WARNING: This method is unsafe and assumes the memory layout is of `sockaddr_t`. !!!

--- a/Sources/NTPClient.swift
+++ b/Sources/NTPClient.swift
@@ -67,7 +67,7 @@ final class NTPClient {
         }
     }
 
-    /// Query the given ntp server for the time exchange.
+    /// Query the given NTP server for the time exchange.
     ///
     /// - parameter ip:              Server socket address.
     /// - parameter port:            Server NTP port (default 123).

--- a/Sources/NTPPacket.swift
+++ b/Sources/NTPPacket.swift
@@ -30,7 +30,7 @@ struct NTPPacket {
     /// The current connection mode.
     let mode: Mode
 
-    /// Mode representing the statrum level of the local clock.
+    /// Mode representing the stratum level of the local clock.
     let stratum: Stratum
 
     /// Indicates the maximum interval between successive messages, in seconds to the nearest power of two.

--- a/Sources/NTPProtocol.swift
+++ b/Sources/NTPProtocol.swift
@@ -30,7 +30,7 @@ enum Mode: Int8 {
     case reserved, symmetricActive, symmetricPassive, client, server, broadcast, reservedNTP, unknown
 }
 
-/// Mode representing the statrum level of the clock.
+/// Mode representing the stratum level of the clock.
 enum Stratum: Int8 {
     case unspecified, primary, secondary, invalid
 

--- a/Sources/TimeFreeze.swift
+++ b/Sources/TimeFreeze.swift
@@ -9,7 +9,7 @@ struct TimeFreeze {
     private let timestamp: TimeInterval
     private let offset: TimeInterval
 
-    /// The stable timestamp adjusted by the most acurrate offset known so far.
+    /// The stable timestamp adjusted by the most accurate offset known so far.
     var adjustedTimestamp: TimeInterval {
         return self.offset + self.stableTimestamp
     }


### PR DESCRIPTION
Noticed a couple of wording issues while reading the source code.

PTAL @Reflejo @keith 