### PR TITLE
Add IPv4 preference support

### DIFF
--- a/Sources/Clock.swift
+++ b/Sources/Clock.swift
@@ -63,15 +63,17 @@ public struct Clock {
     /// - parameter pool:       NTP pool that will be resolved into multiple NTP servers that will be used for
     ///                         the synchronization.
     /// - parameter samples:    The number of samples to be acquired from each server (default 4).
+    /// - parameter preferIPv4: Prefer IPv4 addresses to query if both IPv4 and IPv6 addresses are returned.
     /// - parameter completion: A closure that will be called after _all_ the NTP calls are finished.
     /// - parameter first:      A closure that will be called after the first valid date is calculated.
     public static func sync(from pool: String = "time.apple.com", samples: Int = 4,
+                            preferIPv4: Bool = false,
                             first: ((Date, TimeInterval) -> Void)? = nil,
                             completion: ((Date?, TimeInterval?) -> Void)? = nil)
     {
         self.loadFromDefaults()
 
-        NTPClient().query(pool: pool, numberOfSamples: samples) { offset, done, total in
+        NTPClient().query(pool: pool, numberOfSamples: samples, preferIPv4: preferIPv4) { offset, done, total in
             if let offset = offset {
                 self.stableTime = TimeFreeze(offset: offset)
 


### PR DESCRIPTION
In our tests with Austrian time servers we often see that using IPv6 addresses results in much slower query times (consistently 10 seconds instead of ~4 with only IPv4).

This PR adds a new parameter to the Clock.sync call and NTPClient to allow the preference of IPv4 addresses if both IPv4 and IPv6 addresses are resolved.