### PR TITLE
Add link to Kronos Multiplatform Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,5 @@ $ carthage update
 ```
 
 Looking for Kronos for your Android application? Check out [Kronos for Android](https://github.com/lyft/Kronos-Android)
+
+Looking for Kronos for your Kotlin Multiplatform application? Check out [Kronos Multiplatform Library](https://github.com/softartdev/Kronos-Multiplatform)


### PR DESCRIPTION
Hi there,

I've recently developed a Kotlin Multiplatform library called [Kronos-Multiplatform](https://github.com/softartdev/Kronos-Multiplatform), which uses the Kronos library for iOS, alongside another library for Android. It provides network time synchronization capabilities for Kotlin Multiplatform projects.

Adding a reference in the README.md would be helpful for developers looking for a comprehensive solution for network time synchronization across multiple platforms.

Best regards,
Artur

