### PR TITLE
Updated podspec version

### DIFF
--- a/Kronos.podspec
+++ b/Kronos.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Kronos'
-  s.version = '4.3.0'
+  s.version = '4.3.2'
   s.license = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
   s.summary = 'Elegant NTP client in Swift'
   s.homepage = 'https://github.com/MobileNativeFoundation/Kronos'


### PR DESCRIPTION
The current v4.3.1 support only SPM. Latest for cocoapods is 4.3.0

This PR update the podspec to 4.3.2
